### PR TITLE
Fix direction of graph edges

### DIFF
--- a/daxgen/utils/dax2graphml.py
+++ b/daxgen/utils/dax2graphml.py
@@ -75,8 +75,8 @@ def parse_dax(plan):
                       if entry['@link'] == 'input']
             outputs = [entry['@name'] for entry in resources
                        if entry['@link'] == 'output']
-            dag.add_edges_from([(v, mapping[lfn]) for lfn in inputs])
-            dag.add_edges_from([(mapping[lfn], v) for lfn in outputs])
+            dag.add_edges_from([(mapping[lfn], v) for lfn in inputs])
+            dag.add_edges_from([(v, mapping[lfn]) for lfn in outputs])
 
         # Flag files to which standard streams are redirected.
         streams = {'stderr': 2, 'stdout': 1}


### PR DESCRIPTION
Due to trivial error in list comprehensions responsible for edge
creation, the graph being returned by the converter was the transpose of
the input graph.  Fixed it.